### PR TITLE
Fix binary name

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "import": "./.esm-wrapper.mjs"
   },
   "bin": {
-    "boxnode": "bin/boxednode.js"
+    "boxednode": "bin/boxednode.js"
   },
   "engines": {
     "node": ">= 12.4.0"


### PR DESCRIPTION
As of now the readme example is wrong because it uses `boxednode` for binary name, but it looks like the problem is actually `package.json`. If this is intentional, please update the readme to use `boxnode`.