### PR TITLE
Ignore node-addon-api gyp dependency MONGOSH-1039

### DIFF
--- a/src/native-addons.ts
+++ b/src/native-addons.ts
@@ -86,6 +86,11 @@ async function prepForUsageWithNode (
   (config.includes = config.includes || []).push(
     path.join(nodeGypDir, 'addon.gypi')
   );
+  // Remove node-addon-api gyp dummy, which inserts nothing.c into
+  // the build tree, which can conflict with other target's nothing.c
+  // files.
+  config.dependencies = config.dependencies?.filter(
+    dep => !/require\s*\(.+node-addon-api.+\)\s*\.\s*gyp/.test(dep)) ?? [];
   config.variables = {
     ...(config.variables || {}),
     'node_root_dir%': nodeSourcePath,


### PR DESCRIPTION
This resolves build failures on Windows when including
multiple N-API addons at the same time.