### PR TITLE
feat: allow JSON in `BOXEDNODE_{CONFIGURE,MAKE}_ARGS`

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           check-latest: true
           node-version: ${{ matrix.node-version }}
+      - name: Install npm@8.x
+        run: npm install -g npm@8.x
       - name: Install Dependencies
         run: npm install
       - name: Test
@@ -40,6 +42,8 @@ jobs:
         with:
           check-latest: true
           node-version: ${{ matrix.node-version }}
+      - name: Install npm@8.x
+        run: npm install -g npm@8.x
       - name: Install Dependencies
         run: npm install
       - name: Sharded tests

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gen-esm-wrapper": "^1.1.0",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
-    "ts-node": "^9.0.0",
+    "ts-node": "^10.8.1",
     "typescript": "^4.0.3",
     "weak-napi": "2.0.2"
   },


### PR DESCRIPTION
In mongosh, we introduced `NODE_JS_CONFIGURE_ARGS` (not
remembering that boxednode already provides this capability).
We should just use a single consistent env var throughout
the build process.

This adds JSON array support for these environment variables
for cases in which the list items themselves contain commas,
and, as a drive-by fix, avoids mutating the input options
argument.