### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -40,13 +40,13 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup python
+      - name: Install python
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
       - name: Install Node.js build deps
         run: choco install nasm
-      - name: Setup developer command prompt
+      - name: Install developer command prompt
         uses: ilammy/msvc-dev-cmd@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,14 +35,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
       - name: Install Node.js build deps
         run: choco install nasm
-      - name: Set up developer command prompt
-        uses: ilammy/msvc-dev-cmd@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,6 +2,10 @@ on: [push, pull_request]
 
 name: CI
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
 #  test-posix:
 #    name: Unix tests

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -49,6 +49,7 @@ jobs:
           check-latest: true
           node-version: ${{ matrix.node-version }}
       - name: Install npm@8.x
+        if: ${{ matrix.node-version == '14.x' }}
         run: npm install -g npm@8.x
       - name: Install Dependencies
         run: npm install

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,40 +3,46 @@ on: [push, pull_request]
 name: CI
 
 jobs:
-  test-posix:
-    name: Unix tests
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        node-version: [12.18.4, 12.x, 14.x, 16.x]
-    runs-on: ${{matrix.os}}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
-        with:
-          check-latest: true
-          node-version: ${{ matrix.node-version }}
-      - name: Install npm@8.x
-        run: npm install -g npm@8.x
-      - name: Install Dependencies
-        run: npm install
-      - name: Test
-        run: npm test
+#  test-posix:
+#    name: Unix tests
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        os: [ubuntu-latest, macos-latest]
+#        node-version: [12.18.4, 12.x, 14.x, 16.x]
+#    runs-on: ${{matrix.os}}
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Use Node.js ${{ matrix.node-version }}
+#        uses: actions/setup-node@v2
+#        with:
+#          check-latest: true
+#          node-version: ${{ matrix.node-version }}
+#      - name: Install npm@8.x
+#        run: npm install -g npm@8.x
+#      - name: Install Dependencies
+#        run: npm install
+#      - name: Test
+#        run: npm test
 
   test-windows:
     name: Windows tests
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        node-version: [12.18.4, 12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         shard: [1, 2, 3]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
+      - name: set up python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
       - name: Install Node.js build deps
         run: choco install nasm
+      - name: setup developer command prompt
+        uses: ilammy/msvc-dev-cmd@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,27 +7,28 @@ defaults:
     shell: bash
 
 jobs:
-#  test-posix:
-#    name: Unix tests
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        os: [ubuntu-latest, macos-latest]
-#        node-version: [12.18.4, 12.x, 14.x, 16.x]
-#    runs-on: ${{matrix.os}}
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Use Node.js ${{ matrix.node-version }}
-#        uses: actions/setup-node@v2
-#        with:
-#          check-latest: true
-#          node-version: ${{ matrix.node-version }}
-#      - name: Install npm@8.x
-#        run: npm install -g npm@8.x
-#      - name: Install Dependencies
-#        run: npm install
-#      - name: Test
-#        run: npm test
+  test-posix:
+    name: Unix tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node-version: [14.x, 16.x, 18.x]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          check-latest: true
+          node-version: ${{ matrix.node-version }}
+      - name: Install npm@8.x
+        if: ${{ matrix.node-version == '14.x' }}
+        run: npm install -g npm@8.x
+      - name: Install Dependencies
+        run: npm install
+      - name: Test
+        run: npm test
 
   test-windows:
     name: Windows tests

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,5 +1,9 @@
 on: [push, pull_request]
 
+defaults:
+  run:
+    shell: bash
+
 name: CI
 
 jobs:
@@ -50,8 +54,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install npm@8.x
         run: npm install -g npm@8.x
-      - name: Set VS version
-        run: npm config set msvs_version 2022
       - name: Install Dependencies
         run: npm install
       - name: Sharded tests

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -48,8 +48,8 @@ jobs:
         with:
           check-latest: true
           node-version: ${{ matrix.node-version }}
-#      - name: Install npm@8.x
-#        run: npm install -g npm@8.x
+      - name: Install npm@8.x
+        run: npm install -g npm@8.x
       - name: Install Dependencies
         run: npm install
       - name: Sharded tests

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         node-version: [14.x, 16.x, 18.x]
-    runs-on: ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -33,20 +33,20 @@ jobs:
   test-windows:
     name: Windows tests
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         node-version: [14.x, 16.x, 18.x]
         shard: [1, 2, 3]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up python
+      - name: Setup python
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
       - name: Install Node.js build deps
         run: choco install nasm
-      - name: Set up developer command prompt
+      - name: Setup developer command prompt
         uses: ilammy/msvc-dev-cmd@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,8 +35,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set up python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
       - name: Install Node.js build deps
         run: choco install nasm
+      - name: Set up developer command prompt
+        uses: ilammy/msvc-dev-cmd@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -48,8 +48,8 @@ jobs:
         with:
           check-latest: true
           node-version: ${{ matrix.node-version }}
-      - name: Install npm@8.x
-        run: npm install -g npm@8.x
+#      - name: Install npm@8.x
+#        run: npm install -g npm@8.x
       - name: Install Dependencies
         run: npm install
       - name: Sharded tests

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,9 +1,5 @@
 on: [push, pull_request]
 
-defaults:
-  run:
-    shell: bash
-
 name: CI
 
 jobs:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,13 +35,13 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - name: set up python
+      - name: Set up python
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
       - name: Install Node.js build deps
         run: choco install nasm
-      - name: setup developer command prompt
+      - name: Set up developer command prompt
         uses: ilammy/msvc-dev-cmd@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
@@ -50,6 +50,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install npm@8.x
         run: npm install -g npm@8.x
+      - name: Set VS version
+        run: npm config set msvs_version 2022
       - name: Install Dependencies
         run: npm install
       - name: Sharded tests

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@pkgjs/nv": "^0.2.1",
     "chalk": "^4.1.0",
     "cli-progress": "^3.8.2",
-    "gyp-parser": "^1.0.1",
+    "gyp-parser": "^1.0.4",
     "node-fetch": "^2.6.1",
     "node-gyp": "^9.0.0",
     "pkg-up": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "cli-progress": "^3.8.2",
     "gyp-parser": "^1.0.1",
     "node-fetch": "^2.6.1",
-    "node-gyp": "^7.1.0",
+    "node-gyp": "^9.0.0",
     "pkg-up": "^3.1.0",
     "rimraf": "^3.0.2",
     "semver": "^7.3.2",

--- a/package.json
+++ b/package.json
@@ -50,14 +50,14 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "gen-esm-wrapper": "^1.1.0",
-    "mocha": "^8.1.3",
+    "mocha": "^10.0.0",
     "nyc": "^15.1.0",
     "ts-node": "^10.8.1",
     "typescript": "^4.0.3",
     "weak-napi": "2.0.2"
   },
   "dependencies": {
-    "@pkgjs/nv": "^0.1.0",
+    "@pkgjs/nv": "^0.2.1",
     "chalk": "^4.1.0",
     "cli-progress": "^3.8.2",
     "gyp-parser": "^1.0.1",


### PR DESCRIPTION
Fix #28

Changes
* nodejs.yml
  * Set default shell to bash even on Windows
  * Removed Node.js v12 which reached EOL from the matrix
  * Added Node.js v18 to the matrix
  * Restricted npm v8 installation to Node.js v14
  * Fixed Windows build steps
* package.json
  * Upgraded node-gyp to support VS 2022
  * Upgraded mocha and nv to fix vulnerabilities
