### PR TITLE
feat!: drop support for Node.js 12.x

### DIFF
--- a/resources/third_party_main.js
+++ b/resources/third_party_main.js
@@ -1,1 +1,0 @@
-require(REPLACE_WITH_ENTRY_POINT)


### PR DESCRIPTION
[MONGOSH-1342](https://jira.mongodb.org/browse/MONGOSH-1342)

415eea5950 already dropped this from CI, so it seems reasonable to consider this unsupported either way, but this commit fully removes the code that was used for supporting it.