### PR TITLE
chore: remove source loading indirection

### DIFF
--- a/resources/entry-point-trampoline.js
+++ b/resources/entry-point-trampoline.js
@@ -3,11 +3,9 @@ const Module = require('module');
 const vm = require('vm');
 const path = require('path');
 const {
-  srcMod,
   requireMappings,
   enableBindingsPatch
 } = REPLACE_WITH_BOXEDNODE_CONFIG;
-const src = require(srcMod);
 const hydatedRequireMappings =
   requireMappings.map(([re, reFlags, linked]) => [new RegExp(re, reFlags), linked]);
 
@@ -51,7 +49,7 @@ if (enableBindingsPatch) {
   });
 }
 
-module.exports = (() => {
+module.exports = (src) => {
   const __filename = process.execPath;
   const __dirname = path.dirname(process.execPath);
   const innerRequire = Module.createRequire(__filename);
@@ -85,4 +83,4 @@ module.exports = (() => {
     filename: __filename
   })(__filename, __dirname, require, exports, module);
   return module.exports;
-})();
+};


### PR DESCRIPTION
[MONGOSH-1343](https://jira.mongodb.org/browse/MONGOSH-1343)

Instead of writing a module that exports the main JS source to the generated binary, just include the string as a C++ string. This avoids an extra parsing pass and reduces binary size.