### PR TITLE
feat: allow using default libuv event loop

### DIFF
--- a/bin/boxednode.js
+++ b/bin/boxednode.js
@@ -27,6 +27,9 @@ const argv = require('yargs')
   .option('namespace', {
     alias: 'N', type: 'string', desc: 'Module identifier for the generated binary'
   })
+  .options('use-legacy-default-uv-loop', {
+    type: 'boolean', desc: 'Use the global singleton libuv event loop rather than a separate local one'
+  })
   .example('$0 -s myProject.js -t myProject.exe -n ^14.0.0',
     'Create myProject.exe from myProject.js using Node.js v14')
   .help()
@@ -42,7 +45,8 @@ const argv = require('yargs')
       clean: argv.c,
       configureArgs: (argv.C || '').split(',').filter(Boolean),
       makeArgs: (argv.M || '').split(',').filter(Boolean),
-      namespace: argv.N
+      namespace: argv.N,
+      useLegacyDefaultUvLoop: argv.useLegacyDefaultUvLoop
     });
   } catch (err) {
     console.error(err);

--- a/resources/main-template.cc
+++ b/resources/main-template.cc
@@ -49,23 +49,29 @@ static int RunNodeInstance(MultiIsolatePlatform* platform,
                            const std::vector<std::string>& args,
                            const std::vector<std::string>& exec_args) {
   int exit_code = 0;
+  uv_loop_t* loop;
+#ifndef BOXEDNODE_USE_DEFAULT_UV_LOOP
   // Set up a libuv event loop.
-  uv_loop_t loop;
-  int ret = uv_loop_init(&loop);
+  uv_loop_t loop_;
+  loop = &loop_;
+  int ret = uv_loop_init(loop);
   if (ret != 0) {
     fprintf(stderr, "%s: Failed to initialize loop: %s\n",
             args[0].c_str(),
             uv_err_name(ret));
     return 1;
   }
+#else
+  loop = uv_default_loop();
+#endif
 
   std::shared_ptr<ArrayBufferAllocator> allocator =
       ArrayBufferAllocator::Create();
 
 #if NODE_VERSION_AT_LEAST(14, 0, 0)
-  Isolate* isolate = NewIsolate(allocator, &loop, platform);
+  Isolate* isolate = NewIsolate(allocator, loop, platform);
 #else
-  Isolate* isolate = NewIsolate(allocator.get(), &loop, platform);
+  Isolate* isolate = NewIsolate(allocator.get(), loop, platform);
 #endif
   if (isolate == nullptr) {
     fprintf(stderr, "%s: Failed to initialize V8 Isolate\n", args[0].c_str());
@@ -79,7 +85,7 @@ static int RunNodeInstance(MultiIsolatePlatform* platform,
     // Create a node::IsolateData instance that will later be released using
     // node::FreeIsolateData().
     std::unique_ptr<IsolateData, decltype(&node::FreeIsolateData)> isolate_data(
-        node::CreateIsolateData(isolate, &loop, platform, allocator.get()),
+        node::CreateIsolateData(isolate, loop, platform, allocator.get()),
         node::FreeIsolateData);
 
     // Set up a new v8::Context.
@@ -143,7 +149,7 @@ static int RunNodeInstance(MultiIsolatePlatform* platform,
       SealHandleScope seal(isolate);
       bool more;
       do {
-        uv_run(&loop, UV_RUN_DEFAULT);
+        uv_run(loop, UV_RUN_DEFAULT);
 
         // V8 tasks on background threads may end up scheduling new tasks in the
         // foreground, which in turn can keep the event loop going. For example,
@@ -151,7 +157,7 @@ static int RunNodeInstance(MultiIsolatePlatform* platform,
         platform->DrainTasks(isolate);
 
         // If there are new tasks, continue.
-        more = uv_loop_alive(&loop);
+        more = uv_loop_alive(loop);
         if (more) continue;
 
         // node::EmitBeforeExit() is used to emit the 'beforeExit' event on
@@ -160,7 +166,7 @@ static int RunNodeInstance(MultiIsolatePlatform* platform,
 
         // 'beforeExit' can also schedule new work that keeps the event loop
         // running.
-        more = uv_loop_alive(&loop);
+        more = uv_loop_alive(loop);
       } while (more == true);
     }
 
@@ -185,9 +191,11 @@ static int RunNodeInstance(MultiIsolatePlatform* platform,
 
   // Wait until the platform has cleaned up all relevant resources.
   while (!platform_finished)
-    uv_run(&loop, UV_RUN_ONCE);
-  int err = uv_loop_close(&loop);
+    uv_run(loop, UV_RUN_ONCE);
+#ifndef BOXEDNODE_USE_DEFAULT_UV_LOOP
+  int err = uv_loop_close(loop);
   assert(err == 0);
+#endif
 
   return exit_code;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,7 @@ type CompilationOptions = {
   namespace?: string,
   addons?: AddonConfig[],
   enableBindingsPatch?: boolean,
+  useLegacyDefaultUvLoop?: boolean;
   executableMetadata?: ExecutableMetadata,
   preCompileHook?: (nodeSourceTree: string, options: CompilationOptions) => void | Promise<void>
 }
@@ -279,6 +280,9 @@ async function compileJSFileAsBinaryImpl (options: CompilationOptions, logger: L
       registerFunctions.map((fn) => `${fn},`).join(''));
     mainSource = mainSource.replace(/\bREPLACE_WITH_MAIN_SCRIPT_SOURCE_GETTER\b/g,
       createCppJsStringDefinition('GetBoxednodeMainScriptSource', jsMainSource));
+    if (options.useLegacyDefaultUvLoop) {
+      mainSource = `#define BOXEDNODE_USE_DEFAULT_UV_LOOP 1\n${mainSource}`;
+    }
     await fs.writeFile(path.join(nodeSourcePath, 'src', 'node_main.cc'), mainSource);
     logger.stepCompleted();
   }


### PR DESCRIPTION
This may be required by some legacy addons which refer to the default libuv event loop.

Fixes: https://github.com/mongodb-js/boxednode/issues/36