### PR TITLE
fix: fix CI with Node.js 18+ MONGOSH-1344

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 19.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 19.x]
         shard: [1, 2, 3]
     runs-on: windows-latest
     steps:

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,15 @@ async function getNodeSourceForVersion (range: string, dir: string, logger: Logg
   return path.join(dir, `node-${version}`);
 }
 
+async function getNodeVersionFromSourceDirectory (dir: string): Promise<[number, number, number]> {
+  const versionFile = await fs.readFile(path.join(dir, 'src', 'node_version.h'), 'utf8');
+
+  const major = +versionFile.match(/^#define\s+NODE_MAJOR_VERSION\s+(?<version>\d+)\s*$/m)?.groups?.version;
+  const minor = +versionFile.match(/^#define\s+NODE_MINOR_VERSION\s+(?<version>\d+)\s*$/m)?.groups?.version;
+  const patch = +versionFile.match(/^#define\s+NODE_PATCH_VERSION\s+(?<version>\d+)\s*$/m)?.groups?.version;
+  return [major, minor, patch];
+}
+
 // Compile a Node.js build in a given directory from source
 async function compileNode (
   sourcePath: string,
@@ -162,6 +171,19 @@ async function compileNode (
     logger: logger,
     env: env
   };
+
+  // Node.js 19.4.0 is currently the minimum version that has https://github.com/nodejs/node/pull/45887.
+  // We want to disable the shared-ro-heap flag since it would require
+  // all snapshots used by Node.js to be equal, something that we don't
+  // want to or need to guarantee as embedders.
+  const nodeVersion = await getNodeVersionFromSourceDirectory(sourcePath);
+  if (nodeVersion[0] > 19 || (nodeVersion[0] === 19 && nodeVersion[1] >= 4)) {
+    if (process.platform !== 'win32') {
+      buildArgs.unshift('--disable-shared-readonly-heap');
+    } else {
+      buildArgs.unshift('no_shared_roheap');
+    }
+  }
 
   if (process.platform !== 'win32') {
     const configure: string[] = ['./configure', ...buildArgs];

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ async function compileNode (
     if (process.platform !== 'win32') {
       buildArgs.unshift('--disable-shared-readonly-heap');
     } else {
-      buildArgs.unshift('no_shared_roheap');
+      buildArgs.unshift('no-shared-roheap');
     }
   }
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -61,6 +61,24 @@ describe('basic functionality', () => {
         assert.strictEqual(stdout, 'true\n');
       }
 
+      {
+        const { stdout } = await execFile(
+          path.resolve(__dirname, `resources/example${exeSuffix}`), ['require("vm").runInNewContext("21*2")'],
+          { encoding: 'utf8' });
+        assert.strictEqual(stdout, '42\n');
+      }
+
+      {
+        const { stdout } = await execFile(
+          path.resolve(__dirname, `resources/example${exeSuffix}`), [
+            'new (require("worker_threads").Worker)' +
+              '("require(`worker_threads`).parentPort.postMessage(21*2)", {eval:true})' +
+              '.once("message", console.log);0'
+          ],
+          { encoding: 'utf8' });
+        assert.strictEqual(stdout, '0\n42\n');
+      }
+
       if (process.platform !== 'win32') {
         const proc = childProcess.spawn(
           path.resolve(__dirname, `resources/example${exeSuffix}`),


### PR DESCRIPTION
This should un-break boxednode when building against Node.js versions that have snapshot support, but not in a way that is compatible with the way in which we embed Node.js.