### PR TITLE
fix: fix Cannot redefine property: getFileName

### DIFF
--- a/resources/entry-point-trampoline.js
+++ b/resources/entry-point-trampoline.js
@@ -41,6 +41,7 @@ if (enableBindingsPatch) {
           if (!entry) return entry;
           const origGetFileName = entry.getFileName;
           Object.defineProperty(entry, 'getFileName', {
+            configurable: true,
             value: function(...args) {
               return origGetFileName.call(this, ...args) || '';
             }


### PR DESCRIPTION
This fixes a [TypeError that occurred](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cant_redefine_property) in an e2e test in mongodb-js/mongosh#1427.

```
[Timed out 10000ms] expected prompt
+ expected - actual
-Current Mongosh Log ID:	640b3942e163d12c46b210ce
-Using Mongosh:		0.0.0-dev.0
-
-For mongosh info see: https://docs.mongodb.com/mongodb-shell/
-
-> {
-  key: Binary(Buffer.from("921e06bf637caa8a5940c418304b70c3f0243ec22b5cd9843314ebb37b54a134196d9bb89ac75151a47c5397d70fb03b417607704beebb859cb492e84fe36fbd5dde788837303f8af07f5247bf789bfb1a7e04477487f2e8f0feac5a6f9856d8", "hex"), 0)
-}
-> ... ... ... ... mongodb://localhost:30270/?directConnection=true&serverSelectionTimeoutMS=2000
-> test-1678457154415
-> ... ... ... ... ... ... ... ... ... ... ... 
-> mongodb://localhost:30270/?directConnection=true&serverSelectionTimeoutMS=2000
-> [prompt search starts here]node:mongosh/mongosh:40
-          Object.defineProperty(entry, 'getFileName', {
-                 ^
-
-TypeError: Cannot redefine property: getFileName
-    at Function.defineProperty (<anonymous>)
-    at node:mongosh/mongosh:40:18
-    at eval (eval at innerEval (/private/tmp/m/boxednode/mongosh/node-v16.19.1/out/Release/node:100:360919), <anonymous>:55:67)
-    at Array._arv8.map (eval at innerEval (/private/tmp/m/boxednode/mongosh/node-v16.19.1/out/Release/node:100:360919), <anonymous>:72:182)
-    at Function.epst (node:mongosh/mongosh:37:23)
-    at Function.epst (node:mongosh/mongosh:47:18)
-    at maybeOverridePrepareStackTrace (node:internal/errors:141:29)
-    at prepareStackTrace (node:internal/errors:115:5)
-    at beforeInspector (node:internal/errors:754:20)
-    at processPromiseRejections (node:internal/process/promises:279:13)
-    at processTicksAndRejections (node:internal/process/task_queues:97:32)
+/^([^<>]*> ?)+$/m
```

To alter a property of an `Object` using `defineProperty` said function must have the `descriptor` parameter with its `configurable` field set to true.

Hopefully this change will display a much more accurate log in that PR.
