### PR TITLE
feat!: bump default build tools to vs2022 for Windows MONGOSH-1648

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -66,6 +66,10 @@ functions:
             export BOXEDNODE_CONFIGURE_ARGS='--openssl-no-asm'
           fi
 
+          if [ "$OS" != "Windows_NT" ]; then
+            export PATH="/opt/mongodbtoolchain/v4/bin:$PATH"
+          fi
+
           . .evergreen/use-node.sh
           npm run build
           TEST_NODE_VERSION="$TEST_NODE_VERSION" npm run test-ci

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -46,10 +46,6 @@ functions:
         shell: bash
         env:
           TEST_NODE_VERSION: ${node_version}
-          OKTA_TEST_CONFIG: ${okta_test_config}
-          OKTA_TEST_CREDENTIALS: ${okta_test_credentials}
-          AZURE_TEST_CONFIG: ${azure_test_config}
-          AZURE_TEST_CREDENTIALS: ${azure_test_credentials}
           DISTRO_ID: ${distro_id}
         script: |
           set -e
@@ -75,22 +71,6 @@ functions:
           TEST_NODE_VERSION="$TEST_NODE_VERSION" npm run test-ci
 
 tasks:
-  - name: test_n14
-    commands:
-      - func: checkout
-      - func: install_node
-      - func: install
-      - func: test
-        vars:
-          node_version: "14.21.3"
-  - name: test_n16
-    commands:
-      - func: checkout
-      - func: install_node
-      - func: install
-      - func: test
-        vars:
-          node_version: "16.20.1"
   - name: test_n18
     commands:
       - func: checkout
@@ -107,6 +87,14 @@ tasks:
       - func: test
         vars:
           node_version: "20.13.0"
+  - name: test_n22
+    commands:
+      - func: checkout
+      - func: install_node
+      - func: install
+      - func: test
+        vars:
+          node_version: "22.11.0"
   - name: check
     commands:
       - func: checkout
@@ -119,32 +107,28 @@ buildvariants:
     display_name: 'Ubuntu 20.04 x64'
     run_on: ubuntu2004-large
     tasks:
-      - test_n14
-      - test_n16
       - test_n18
       - test_n20
+      - test_n22
       - check
   - name: macos_x64_test
-    display_name: 'macOS 11.00 x64'
-    run_on: macos-1100
+    display_name: 'macOS 14 x64'
+    run_on: macos-14
     tasks:
-      - test_n14
-      - test_n16
       - test_n18
       - test_n20
+      - test_n22
   - name: macos_arm64_test
-    display_name: 'macOS 11.00 arm64'
-    run_on: macos-1100-arm64
+    display_name: 'macOS 14 arm64'
+    run_on: macos-14-arm64
     tasks:
-      - test_n14
-      - test_n16
       - test_n18
       - test_n20
+      - test_n22
   - name: windows_x64_test
     display_name: 'Windows x64'
     run_on: windows-vsCurrent-2022-large
     tasks:
-      - test_n14
-      - test_n16
       - test_n18
       - test_n20
+      - test_n22

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -142,7 +142,7 @@ buildvariants:
       - test_n20
   - name: windows_x64_test
     display_name: 'Windows x64'
-    run_on: windows-vsCurrent-xlarge
+    run_on: windows-vsCurrent-2022-large
     tasks:
       - test_n14
       - test_n16

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,7 +248,7 @@ async function compileNode (
     // conflicting arguments have been passed manually.
     const vcbuildArgs: string[] = [...buildArgs, ...makeArgs, 'projgen'];
     if (!vcbuildArgs.includes('debug') && !vcbuildArgs.includes('release')) { vcbuildArgs.push('release'); }
-    if (!vcbuildArgs.some((arg) => /^vs/.test(arg))) { vcbuildArgs.push('vs2019'); }
+    if (!vcbuildArgs.some((arg) => /^vs/.test(arg))) { vcbuildArgs.push('vs2022'); }
 
     for (const module of linkedJSModules) {
       vcbuildArgs.push('link-module', module);


### PR DESCRIPTION
According to https://github.com/nodejs/node/pull/49051 the Node.js team dropped support for vs2019, so we need to upgrade BoxedNode to use vs2022 as the default toolchain. ~Compiling with vs2019 will still be possible by providing the extra argument `vs2019`.~.