### PR TITLE
fix: work around Node.js April 2024 security release

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -253,7 +253,7 @@ async function compileNode (
     for (const module of linkedJSModules) {
       vcbuildArgs.push('link-module', module);
     }
-    await spawnBuildCommand(['.\\vcbuild.bat', ...vcbuildArgs], options);
+    await spawnBuildCommand(['cmd', '/c', '.\\vcbuild.bat', ...vcbuildArgs], options);
 
     return path.join(sourcePath, 'Release', 'node.exe');
   }


### PR DESCRIPTION
https://github.com/nodejs/node/commit/9095c914ed8467cf16f077a3fac20b1f1e89bbe4 disallowed spawning `.bat` files directly, without running them inside of a shell such as `cmd`. Boxednode needs to be adjusted for this.