### PR TITLE
feat: enable optionally enabling/disabling blob compression MONGOSH-1759

### DIFF
--- a/bin/boxednode.js
+++ b/bin/boxednode.js
@@ -54,7 +54,8 @@ const argv = require('yargs')
       namespace: argv.N,
       useLegacyDefaultUvLoop: argv.useLegacyDefaultUvLoop,
       useCodeCache: argv.H,
-      useNodeSnapshot: argv.S
+      useNodeSnapshot: argv.S,
+      compressBlobs: argv.Z
     });
   } catch (err) {
     console.error(err);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -107,6 +107,21 @@ export function createCppJsStringDefinition (fnName: string, source: string): st
   `;
 }
 
+export async function createUncompressedBlobDefinition (fnName: string, source: Uint8Array): Promise<string> {
+  return `
+  static const uint8_t ${fnName}_source_[] = {
+    ${Uint8Array.prototype.toString.call(source) || '0'}
+  };
+
+  std::vector<char> ${fnName}Vector() {
+    return std::vector<char>(
+      reinterpret_cast<const char*>(&${fnName}_source_[0]),
+      reinterpret_cast<const char*>(&${fnName}_source_[${source.length}]));
+  }
+
+  ${blobTypedArrayAccessors(fnName, source.length)}`;
+}
+
 export async function createCompressedBlobDefinition (fnName: string, source: Uint8Array): Promise<string> {
   const compressed = await promisify(zlib.brotliCompress)(source, {
     params: {
@@ -133,13 +148,6 @@ export async function createCompressedBlobDefinition (fnName: string, source: Ui
     assert(decoded_size == ${source.length});
   }
 
-  std::string ${fnName}() {
-    ${source.length === 0 ? 'return {};' : `
-    std::string dst(${source.length}, 0);
-    ${fnName}_Read(&dst[0]);
-    return dst;`}
-  }
-
   std::vector<char> ${fnName}Vector() {
     ${source.length === 0 ? 'return {};' : `
     std::vector<char> dst(${source.length});
@@ -147,19 +155,25 @@ export async function createCompressedBlobDefinition (fnName: string, source: Ui
     return dst;`}
   }
 
+  ${blobTypedArrayAccessors(fnName, source.length)}
+  `;
+}
+
+function blobTypedArrayAccessors (fnName: string, sourceLength: number): string {
+  return `
   std::shared_ptr<v8::BackingStore> ${fnName}BackingStore() {
-    std::string* str = new std::string(std::move(${fnName}()));
+    std::vector<char>* str = new std::vector<char>(std::move(${fnName}Vector()));
     return v8::SharedArrayBuffer::NewBackingStore(
       &str->front(),
       str->size(),
       [](void*, size_t, void* deleter_data) {
-        delete static_cast<std::string*>(deleter_data);
+        delete static_cast<std::vector<char>*>(deleter_data);
       },
       static_cast<void*>(str));
   }
 
   v8::Local<v8::Uint8Array> ${fnName}Buffer(v8::Isolate* isolate) {
-    ${source.length === 0 ? `
+    ${sourceLength === 0 ? `
     auto array_buffer = v8::SharedArrayBuffer::New(isolate, 0);
     ` : `
     auto array_buffer = v8::SharedArrayBuffer::New(isolate, ${fnName}BackingStore());


### PR DESCRIPTION
While blobs such as startup snapshots (40MB in the case of mongosh) can be quite large and compressing them saves binary size, decompressing them also costs non-trivial startup time. We make compression optional in this commit so that we can turn it off in mongosh.