### PR TITLE
fix: remove heap allocation for startup snapshot where possible MONGOSH-1771

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -14,7 +14,7 @@ functions:
           set -e
           set -x
 
-          export NODE_VERSION=20.5.0
+          export NODE_VERSION=20.13.0
           bash .evergreen/install-node.sh
   install:
     - command: shell.exec
@@ -106,7 +106,7 @@ tasks:
       - func: install
       - func: test
         vars:
-          node_version: "20.5.0"
+          node_version: "20.13.0"
   - name: check
     commands:
       - func: checkout

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: [14.x, 16.x, 18.x, 19.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/resources/main-template.cc
+++ b/resources/main-template.cc
@@ -18,6 +18,7 @@
 #include <openssl/rand.h>
 #endif
 #include <type_traits> // injected code may refer to std::underlying_type
+#include <optional>
 
 using namespace node;
 using namespace v8;
@@ -32,6 +33,12 @@ using namespace v8;
 // can be sure of its presence.
 #if NODE_VERSION_AT_LEAST(20, 0, 0)
 #define NODE_VERSION_SUPPORTS_EMBEDDER_SNAPSHOT 1
+#endif
+
+// 20.13.0 has https://github.com/nodejs/node/pull/52595 for better startup snapshot
+// initialization performance.
+#if NODE_VERSION_AT_LEAST(20, 13, 0)
+#define NODE_VERSION_SUPPORTS_STRING_VIEW_SNAPSHOT 1
 #endif
 
 // Snapshot config is supported since https://github.com/nodejs/node/pull/50453
@@ -81,6 +88,7 @@ void MarkTime(const char* category, const char* label) {
 Local<String> GetBoxednodeMainScriptSource(Isolate* isolate);
 Local<Uint8Array> GetBoxednodeCodeCacheBuffer(Isolate* isolate);
 std::vector<char> GetBoxednodeSnapshotBlobVector();
+std::optional<std::string_view> GetBoxednodeSnapshotBlobSV();
 
 void GetTimingData(const FunctionCallbackInfo<Value>& info) {
   Isolate* isolate = info.GetIsolate();
@@ -230,11 +238,18 @@ static int RunNodeInstance(MultiIsolatePlatform* platform,
       ArrayBufferAllocator::Create();
 
 #ifdef BOXEDNODE_CONSUME_SNAPSHOT
-  std::vector<char> snapshot_blob_vec = boxednode::GetBoxednodeSnapshotBlobVector();
-  boxednode::MarkTime("Node.js Instance", "Decoded snapshot");
   assert(EmbedderSnapshotData::CanUseCustomSnapshotPerIsolate());
-  node::EmbedderSnapshotData::Pointer snapshot_blob =
-    EmbedderSnapshotData::FromBlob(snapshot_blob_vec);
+  node::EmbedderSnapshotData::Pointer snapshot_blob;
+#ifdef NODE_VERSION_SUPPORTS_STRING_VIEW_SNAPSHOT
+  if (const auto snapshot_blob_sv = boxednode::GetBoxednodeSnapshotBlobSV()) {
+    snapshot_blob = EmbedderSnapshotData::FromBlob(snapshot_blob_sv.value());
+  }
+#endif
+  if (!snapshot_blob) {
+    std::vector<char> snapshot_blob_vec = boxednode::GetBoxednodeSnapshotBlobVector();
+    boxednode::MarkTime("Node.js Instance", "Decoded snapshot");
+    snapshot_blob = EmbedderSnapshotData::FromBlob(snapshot_blob_vec);
+  }
   boxednode::MarkTime("Node.js Instance", "Read snapshot");
   Isolate* isolate = NewIsolate(allocator, loop, platform, snapshot_blob.get());
 #elif NODE_VERSION_AT_LEAST(14, 0, 0)

--- a/resources/main-template.cc
+++ b/resources/main-template.cc
@@ -88,7 +88,9 @@ void MarkTime(const char* category, const char* label) {
 Local<String> GetBoxednodeMainScriptSource(Isolate* isolate);
 Local<Uint8Array> GetBoxednodeCodeCacheBuffer(Isolate* isolate);
 std::vector<char> GetBoxednodeSnapshotBlobVector();
+#ifdef NODE_VERSION_SUPPORTS_STRING_VIEW_SNAPSHOT
 std::optional<std::string_view> GetBoxednodeSnapshotBlobSV();
+#endif
 
 void GetTimingData(const FunctionCallbackInfo<Value>& info) {
   Isolate* isolate = info.GetIsolate();

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -113,6 +113,15 @@ export async function createUncompressedBlobDefinition (fnName: string, source: 
     ${Uint8Array.prototype.toString.call(source) || '0'}
   };
 
+  std::optional<std::string_view> ${fnName}SV() {
+    return {
+      {
+        reinterpret_cast<const char*>(&${fnName}_source_[0]),
+        ${source.length}
+      }
+    };
+  }
+
   std::vector<char> ${fnName}Vector() {
     return std::vector<char>(
       reinterpret_cast<const char*>(&${fnName}_source_[0]),
@@ -153,6 +162,10 @@ export async function createCompressedBlobDefinition (fnName: string, source: Ui
     std::vector<char> dst(${source.length});
     ${fnName}_Read(&dst[0]);
     return dst;`}
+  }
+
+  std::optional<std::string_view> ${fnName}SV() {
+    return {};
   }
 
   ${blobTypedArrayAccessors(fnName, source.length)}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -113,6 +113,7 @@ export async function createUncompressedBlobDefinition (fnName: string, source: 
     ${Uint8Array.prototype.toString.call(source) || '0'}
   };
 
+#ifdef NODE_VERSION_SUPPORTS_STRING_VIEW_SNAPSHOT
   std::optional<std::string_view> ${fnName}SV() {
     return {
       {
@@ -121,6 +122,7 @@ export async function createUncompressedBlobDefinition (fnName: string, source: 
       }
     };
   }
+#endif
 
   std::vector<char> ${fnName}Vector() {
     return std::vector<char>(
@@ -164,9 +166,11 @@ export async function createCompressedBlobDefinition (fnName: string, source: Ui
     return dst;`}
   }
 
+#ifdef NODE_VERSION_SUPPORTS_STRING_VIEW_SNAPSHOT
   std::optional<std::string_view> ${fnName}SV() {
     return {};
   }
+#endif
 
   ${blobTypedArrayAccessors(fnName, source.length)}
   `;

--- a/test/index.ts
+++ b/test/index.ts
@@ -218,7 +218,7 @@ describe('basic functionality', () => {
       it(`works with snapshot support (compressBlobs = ${compressBlobs})`, async function () {
         this.timeout(2 * 60 * 60 * 1000); // 2 hours
         await compileJSFileAsBinary({
-          nodeVersionRange: '^22.1.0',
+          nodeVersionRange: '^20.13.0',
           sourceFile: path.resolve(__dirname, 'resources/snapshot-echo-args.js'),
           targetFile: path.resolve(__dirname, `resources/snapshot-echo-args${exeSuffix}`),
           useNodeSnapshot: true,

--- a/test/index.ts
+++ b/test/index.ts
@@ -218,7 +218,7 @@ describe('basic functionality', () => {
       it(`works with snapshot support (compressBlobs = ${compressBlobs})`, async function () {
         this.timeout(2 * 60 * 60 * 1000); // 2 hours
         await compileJSFileAsBinary({
-          nodeVersionRange: '^21.6.2',
+          nodeVersionRange: '^22.1.0',
           sourceFile: path.resolve(__dirname, 'resources/snapshot-echo-args.js'),
           targetFile: path.resolve(__dirname, `resources/snapshot-echo-args${exeSuffix}`),
           useNodeSnapshot: true,


### PR DESCRIPTION
Use `std::string_view` instead of `std::vector<>` now that the Node.js embedder API allows it.